### PR TITLE
Fix: Filter recent searches by registry

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PkgFinder",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A lightweight omnibox extension for smart, fast package discovery.",
   "omnibox": {
     "keyword": "pkg"

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,11 +3,14 @@ import { fetchSuggestionsByPrefix, resolvePackageUrl } from './modules/core/regi
 import { toggleFlairMode } from './modules/core/settings.js';
 
 chrome.omnibox.onInputChanged.addListener(async (text, suggest) => {
-    const [prefix, ...queryParts] = text.trim().split(' ');
-    const query = queryParts.join(' ') || prefix;
+    const parts = text.trim().split(' ');
+    const [prefix, ...queryParts] = parts;
+    const query = queryParts.join(' ');
+    const hasQuery = query.trim().length > 0;
+    const hasPrefixOnly = parts.length === 1 && prefix.length > 0;
 
-    if (!query) {
-        const recent = await getRecentSearches();
+    if (!hasQuery && hasPrefixOnly) {
+        const recent = await getRecentSearches(prefix);
         suggest(recent.map(q => ({
             content: q,
             description: `Recent search: ${q}`

--- a/src/modules/core/storage.ts
+++ b/src/modules/core/storage.ts
@@ -1,15 +1,32 @@
-export async function getRecentSearches(): Promise<string[]> {
+export async function getRecentSearches(registry?: string): Promise<string[]> {
     return new Promise(resolve => {
         chrome.storage.local.get(['pkg_recent'], result => {
-            resolve(result.recent || []);
+            const recentRaw = result.pkg_recent ?? {};
+            const recent = recentRaw as Record<string, string[]>;
+
+            if (registry) {
+                resolve(recent[registry] ?? []);
+            } else {
+                // Flatten all history arrays
+                const merged: string[] = Object.values(recent)
+                    .flat()
+                    .filter((v): v is string => true);
+                resolve(merged);
+            }
         });
     });
 }
 
 export async function storeRecentSearch(search: string): Promise<void> {
-    const recent = await getRecentSearches();
-    const updated = [search, ...recent.filter(s => s !== search)].slice(0, 5);
+    const [prefix] = search.trim().split(' ');
+    const all = await new Promise<Record<string, string[]>>(resolve =>
+        chrome.storage.local.get('pkg_recent', res => resolve(res.pkg_recent || {}))
+    );
+
+    const existing = all[prefix] || [];
+    const updated = [search, ...existing.filter(s => s !== search)].slice(0, 5);
+
     return new Promise(resolve => {
-        chrome.storage.local.set({ pkg_recent: updated }, resolve);
+        chrome.storage.local.set({ pkg_recent: { ...all, [prefix]: updated } }, resolve);
     });
 }


### PR DESCRIPTION
### 🚀 Summary
This pull request implements recent search filtering based on the selected registry prefix (`npm`, `py`, etc.) when using the omnibox. This improves UX by only showing relevant past searches.

### ✅ What’s Changed
* Refactored `onInputChanged` to parse and filter `pkg_recent` by registry.
* Updated `getRecentSearches` to support filtering logic.
* Enhanced suggestion logic to handle empty inputs with a prefix (`pkg npm ⏎`).

### 📦 Fixes
Closes #2

### 🧪 How to Test

1. Use the extension in the omnibox: type `pkg npm` then a query. 
2. Confirm only npm-related recent entries appear as suggestions.
3. Try with no query and different prefixes (e.g., `pkg npm`, `pkg crates`).